### PR TITLE
Refactor: Move quad rendering to Renderer

### DIFF
--- a/include/Renderer.h
+++ b/include/Renderer.h
@@ -1,31 +1,23 @@
-#pragma once
+#ifndef RENDERER_H
+#define RENDERER_H
 
 #include <glad/glad.h>
-#include <string>
+#include <GLFW/glfw3.h>
 
 class Renderer {
 public:
-    Renderer();
-    ~Renderer();
-
-    // Initializes the renderer: loads compositing shader, creates quad VAO.
-    // Returns true on success, false on failure.
+    Renderer() = default;
     bool Init();
-
-    // Renders a texture to a fullscreen quad using the compositing shader.
     void RenderFullscreenTexture(GLuint textureID);
-
-    // Optional: A generic method to draw the managed fullscreen quad,
-    // could be used by ShaderEffect if it doesn't manage its own VAO.
-    // void DrawQuad();
+    void RenderQuad(); // This will draw the quad using its own VAO
 
 private:
-    GLuint m_textureDisplayProgram = 0;
+    GLuint m_compositingProgram = 0;
     GLuint m_quadVAO = 0;
     GLuint m_quadVBO = 0;
 
-    // Shader loading and compilation helper (can be static or private)
-    GLuint CompileAndLinkShaderProgram(const char* vertexPath, const char* fragmentPath);
-    // Helper to load shader source from file (can be static or private)
-    std::string LoadShaderSource(const char* filePath, std::string& errorMsg);
+    void setupQuad();
+    bool setupCompositingShader();
 };
+
+#endif // RENDERER_H


### PR DESCRIPTION
- Moved quad VAO/VBO from global scope to Renderer class.
- Renderer::Init now calls setupQuad to initialize these buffers.
- Added Renderer::RenderQuad to draw the managed quad.
- ShaderEffect::Render now only prepares shader, FBO, and uniforms.
- main.cpp updated to remove global quad and call Renderer::RenderQuad in the effect loop.
- Ensured project compiles successfully after changes.