### PR TITLE
Attempt to fix compilation errors and refine render pipeline.

### DIFF
--- a/src/ShaderEffect.cpp
+++ b/src/ShaderEffect.cpp
@@ -381,7 +381,6 @@ void ShaderEffect::Render() {
         if (m_uLightPosLoc != -1) glUniform3fv(m_uLightPosLoc, 1, m_lightPosition);
         if (m_uLightColorLoc != -1) glUniform3fv(m_uLightColorLoc, 1, m_lightColor);
     }
-  
     if (m_iAudioAmpLoc != -1) {
         glUniform1f(m_iAudioAmpLoc, m_audioAmp);
     }
@@ -778,9 +777,6 @@ void ShaderEffect::CompileAndLinkShader() {
     std::string finalFragmentCode = m_shaderSourceCode;
     // Check if the source already contains a main function
     bool hasMainFunction = m_shaderSourceCode.find("void main()") != std::string::npos ||
-
-    bool hasMainFunction = m_shaderSourceCode.find("void main()") != std::string::npos || 
-
                            m_shaderSourceCode.find("void main(void)") != std::string::npos;
 
     if (m_isShadertoyMode && !hasMainFunction) { // <-- ADDED !hasMainFunction CHECK
@@ -905,10 +901,6 @@ void ShaderEffect::FetchUniformLocations() {
 
         m_iTimeDeltaLocation = m_iFrameLocation = m_iMouseLocation = m_iUserFloat1Loc = m_iUserColor1Loc = -1;
     }
-    
-    // Common uniform for both modes, if present
-    m_iAudioAmpLoc = glGetUniformLocation(m_shaderProgram, "iAudioAmp");
-    // if (m_iAudioAmpLoc == -1) warnings_collector += "Warn: iAudioAmp uniform not found.\n"; // Optional warning
 
     // Common uniform for both modes, if present
     m_iAudioAmpLoc = glGetUniformLocation(m_shaderProgram, "iAudioAmp");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -423,9 +423,7 @@ int main() {
     ImGui::CreateContext();
     ImNodes::CreateContext();
     ImGuiIO& io = ImGui::GetIO(); (void)io;
-
-    io.ConfigFlags |= ImGuiConfigFlags_DockingEnable; // <-- ENABLED FOR DOCKSPACE
-
+    // io.ConfigFlags |= ImGuiConfigFlags_DockingEnable; // <-- DISABLED FOR COMPATIBILITY (as per original file and compiler errors)
     ImGui::StyleColorsDark();
     ImGui_ImplGlfw_InitForOpenGL(window, true);
     ImGui_ImplOpenGL3_Init("#version 330");
@@ -481,10 +479,10 @@ int main() {
             }
         }
         std::vector<Effect*> renderQueue = GetRenderOrder(activeEffects);
+
         float audioAmp = g_audioSystem.GetCurrentAmplitude(); // Keep this
 
         // --- RENDER-TO-FBO PASS ---
-        float audioAmp = g_audioSystem.GetCurrentAmplitude();
         for (Effect* effect_ptr : renderQueue) {
             // 1. Prepare the effect's shader and uniforms. This binds the FBO and shader program.
             //    (Update audio amplitude if it's a ShaderEffect)
@@ -494,8 +492,6 @@ int main() {
                 se->SetDeltaTime(deltaTime);
                 se->IncrementFrameCount();
                 se->SetAudioAmplitude(audioAmp);
-                se->SetAudioAmplitude(audioAmp); // Set audio amplitude
-
             }
             effect_ptr->Update(currentTime);
             effect_ptr->Render();
@@ -512,6 +508,7 @@ int main() {
         ImGui_ImplOpenGL3_NewFrame();
         ImGui_ImplGlfw_NewFrame();
         ImGui::NewFrame();
+
         // Dockspace creation commented out due to compilation errors, likely ImGui version/config without docking.
         // // Create the main dockspace
         // ImGuiWindowFlags window_flags = ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoDocking;
@@ -531,24 +528,6 @@ int main() {
         
         if (g_showGui) {
             RenderMenuBar(); // MenuBar would normally be part of the DockSpace window itself
-        // Create the main dockspace
-        ImGuiWindowFlags window_flags = ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoDocking;
-        const ImGuiViewport* viewport = ImGui::GetMainViewport();
-        ImGui::SetNextWindowPos(viewport->WorkPos);
-        ImGui::SetNextWindowSize(viewport->WorkSize);
-        ImGui::SetNextWindowViewport(viewport->ID);
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
-        window_flags |= ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove;
-        window_flags |= ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus;
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
-        ImGui::Begin("MainDockspace", nullptr, window_flags);
-        ImGui::PopStyleVar(3);
-        ImGuiID dockspace_id = ImGui::GetID("MyDockSpace");
-        ImGui::DockSpace(dockspace_id, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_None);
-        
-        if (g_showGui) {
-            RenderMenuBar(); // MenuBar should be part of the DockSpace window itself
             RenderShaderEditorWindow();
             RenderEffectPropertiesWindow();
             RenderTimelineWindow();


### PR DESCRIPTION
- Ensures AudioSystem placeholder is defined in main.cpp.
- Comments out ImGui docking features to resolve compilation issues due to unavailable docking API in the current ImGui setup.
- Corrects the main render loop to use effect->Render() for GL state setup and then g_renderer.RenderQuad() for drawing to FBO.
- Refines ShaderEffect::Render() to only manage FBO, shader, and uniforms, without direct draw calls.

This set of changes aims to address the compilation errors reported (AudioSystem undefined, ImGui docking symbols missing) and incorporates the requested render pipeline modifications.