### PR TITLE
feat: Add detailed iChannel0 logging and fix passthrough uniform

### DIFF
--- a/shaders/passthrough.frag
+++ b/shaders/passthrough.frag
@@ -3,11 +3,11 @@ out vec4 FragColor;
 
 in vec2 TexCoords; // Assuming this comes from a standard fullscreen vert shader
 
-uniform sampler2D u_inputTexture; // Texture from the previous effect in the chain
+uniform sampler2D iChannel0; // Texture from the previous effect in the chain (RENAMED from u_inputTexture)
 uniform float iTime; // Just to make it do something if no input
 
 void main() {
-    vec4 inputColor = texture(u_inputTexture, TexCoords);
+    vec4 inputColor = texture(iChannel0, TexCoords); // Use iChannel0
 
     // If no input texture is properly bound, texture() might return black or undefined.
     // Let's add a fallback or a slight modification to see if the shader is working.

--- a/src/ShaderEffect.cpp
+++ b/src/ShaderEffect.cpp
@@ -335,10 +335,20 @@ void ShaderEffect::Render() {
     if (!m_inputs.empty() && m_inputs[0] != nullptr) {
         if (auto* inputSE = dynamic_cast<ShaderEffect*>(m_inputs[0])) {
             GLuint inputTextureID = inputSE->GetOutputTexture();
+            if (this->name == "Passthrough (Final Output)") { // Specific log for Passthrough
+                std::cerr << "ShaderEffect::Render for Passthrough: inputSE=" << inputSE->name
+                          << ", inputTextureID=" << inputTextureID
+                          << ", m_iChannel0SamplerLoc=" << m_iChannel0SamplerLoc << std::endl;
+            }
             if (inputTextureID != 0 && m_iChannel0SamplerLoc != -1) {
+                 if (this->name == "Passthrough (Final Output)") {
+                    std::cerr << "ShaderEffect::Render for Passthrough: Binding iChannel0 with texture ID " << inputTextureID << std::endl;
+                }
                 glActiveTexture(GL_TEXTURE0);
                 glBindTexture(GL_TEXTURE_2D, inputTextureID);
                 glUniform1i(m_iChannel0SamplerLoc, 0);
+            } else if (this->name == "Passthrough (Final Output)" && m_iChannel0SamplerLoc != -1 && inputTextureID == 0) {
+                 std::cerr << "ShaderEffect::Render for Passthrough: Input texture ID is 0. Not binding iChannel0." << std::endl;
             }
         }
     }
@@ -851,9 +861,10 @@ void ShaderEffect::FetchUniformLocations() {
     if (m_shaderProgram == 0) return;
     std::string warnings_collector;
     m_iChannel0SamplerLoc = glGetUniformLocation(m_shaderProgram, "iChannel0"); // Use "iChannel0"
+    std::cerr << "ShaderEffect::FetchUniformLocations for " << name << ": m_iChannel0SamplerLoc = " << m_iChannel0SamplerLoc << std::endl;
     if (m_iChannel0SamplerLoc == -1) {
         // It's common for shaders not to use iChannel0, so this might be more of a debug log than a warning.
-        // std::cout << "Debug: Uniform 'iChannel0' not found in shader for effect: " << name << std::endl;
+         std::cerr << "ShaderEffect::FetchUniformLocations for " << name << ": Uniform 'iChannel0' not found." << std::endl;
         // warnings_collector += "Info: Uniform 'iChannel0' not found.\n"; // Or make it less alarming
     }
 


### PR DESCRIPTION
- Added std::cerr logging in ShaderEffect::FetchUniformLocations to display the queried location for iChannel0.
- Added std::cerr logging in ShaderEffect::Render to detail the binding of iChannel0 for the Passthrough effect, including the input texture ID.
- Corrected uniform sampler name in shaders/passthrough.frag from u_inputTexture to iChannel0 to match ShaderEffect's expectation.

These changes further aid in diagnosing the black screen issue by providing more specific information about texture input to shaders. This commit also includes prior changes for pausing the timeline on startup and initial diagnostic logging.