### PR TITLE
debug: Force Plasma output to green, add iResolution to Passthrough

### DIFF
--- a/shaders/passthrough.frag
+++ b/shaders/passthrough.frag
@@ -5,6 +5,7 @@ in vec2 TexCoords; // Assuming this comes from a standard fullscreen vert shader
 
 uniform sampler2D iChannel0; // Texture from the previous effect in the chain (RENAMED from u_inputTexture)
 uniform float iTime; // Just to make it do something if no input
+uniform vec3 iResolution; // Added to silence warning & for fallback pattern
 
 void main() {
     vec4 inputColor = texture(iChannel0, TexCoords); // Use iChannel0

--- a/shaders/raymarch_v1.frag
+++ b/shaders/raymarch_v1.frag
@@ -210,4 +210,7 @@ void main() {
     // Basic gamma correction
     col = pow(col, vec3(1.0/2.2));
     FragColor = vec4(col, 1.0);
+
+    // DEBUG: Force output to green
+    FragColor = vec4(0.0, 1.0, 0.0, 1.0);
 }


### PR DESCRIPTION
- Modified shaders/raymarch_v1.frag to unconditionally output green. This is a diagnostic step to verify the rendering pipeline. If the screen shows green (or green tinted by passthrough), it confirms the FBO-to-screen pipeline is working and the original black screen from Plasma was due to its rendering logic at iTime=0.
- Added 'uniform vec3 iResolution;' to shaders/passthrough.frag to address a compiler warning and ensure its fallback diagnostic pattern can function if needed.