### PR TITLE
debug: Add extensive OpenGL error checking and related fixes

### DIFF
--- a/src/ShaderEffect.cpp
+++ b/src/ShaderEffect.cpp
@@ -18,8 +18,9 @@ static void checkGLErrorInEffect(const std::string& label, const std::string& ef
             case GL_INVALID_ENUM: errorStr = "INVALID_ENUM"; break;
             case GL_INVALID_VALUE: errorStr = "INVALID_VALUE"; break;
             case GL_INVALID_OPERATION: errorStr = "INVALID_OPERATION"; break;
-            case GL_STACK_OVERFLOW: errorStr = "STACK_OVERFLOW"; break;
-            case GL_STACK_UNDERFLOW: errorStr = "STACK_UNDERFLOW"; break;
+            // GL_STACK_OVERFLOW and GL_STACK_UNDERFLOW are deprecated and may not be defined
+            // case GL_STACK_OVERFLOW: errorStr = "STACK_OVERFLOW"; break;
+            // case GL_STACK_UNDERFLOW: errorStr = "STACK_UNDERFLOW"; break;
             case GL_OUT_OF_MEMORY: errorStr = "OUT_OF_MEMORY"; break;
             case GL_INVALID_FRAMEBUFFER_OPERATION: errorStr = "INVALID_FRAMEBUFFER_OPERATION"; break;
             default: errorStr = "UNKNOWN_ERROR (" + std::to_string(err) + ")"; break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -176,8 +176,9 @@ void checkGLError(const std::string& label, bool logToGlobalConsole = true) {
             case GL_INVALID_ENUM: errorStr = "INVALID_ENUM"; break;
             case GL_INVALID_VALUE: errorStr = "INVALID_VALUE"; break;
             case GL_INVALID_OPERATION: errorStr = "INVALID_OPERATION"; break;
-            case GL_STACK_OVERFLOW: errorStr = "STACK_OVERFLOW"; break; // Should not happen with modern GL
-            case GL_STACK_UNDERFLOW: errorStr = "STACK_UNDERFLOW"; break; // Should not happen with modern GL
+            // GL_STACK_OVERFLOW and GL_STACK_UNDERFLOW are deprecated and may not be defined
+            // case GL_STACK_OVERFLOW: errorStr = "STACK_OVERFLOW"; break;
+            // case GL_STACK_UNDERFLOW: errorStr = "STACK_UNDERFLOW"; break;
             case GL_OUT_OF_MEMORY: errorStr = "OUT_OF_MEMORY"; break;
             case GL_INVALID_FRAMEBUFFER_OPERATION: errorStr = "INVALID_FRAMEBUFFER_OPERATION"; break;
             default: errorStr = "UNKNOWN_ERROR (" + std::to_string(err) + ")"; break;


### PR DESCRIPTION
- Removed deprecated GL_STACK_OVERFLOW/UNDERFLOW from checkGLError in main.cpp and checkGLErrorInEffect in ShaderEffect.cpp to resolve build errors.
- Added comprehensive OpenGL error checking (glGetError) throughout the rendering pipeline in main.cpp and ShaderEffect.cpp.
- This commit also includes previous diagnostic changes:
  - Plasma shader (raymarch_v1.frag) hardcoded to output green.
  - Passthrough shader (passthrough.frag) declares iResolution and has distinct fallback colors.
  - Programmatic linking of Plasma to Passthrough on startup.
  - Timeline paused on startup by default.
  - Detailed logging for iChannel0 and effect lifecycle.