### PR TITLE
feat: Default to continuous animation, add optional timeline control

### DIFF
--- a/shaders/passthrough.frag
+++ b/shaders/passthrough.frag
@@ -10,21 +10,11 @@ uniform vec3 iResolution; // Added to silence warning & for fallback pattern
 void main() {
     vec4 inputColor = texture(iChannel0, TexCoords); // Use iChannel0
 
-    // If no input texture is properly bound, texture() might return black or undefined.
-    // Let's add a fallback or a slight modification to see if the shader is working.
-    // Check if input is effectively black (very dark) or fully transparent
-    bool isBlack = (inputColor.r < 0.01 && inputColor.g < 0.01 && inputColor.b < 0.01);
-    bool isTransparent = inputColor.a < 0.01;
+    // Simple effect: desaturate or tint the input
+    // float grayscale = dot(inputColor.rgb, vec3(0.299, 0.587, 0.114));
+    // FragColor = vec4(vec3(grayscale), inputColor.a); // Grayscale
+    FragColor = vec4(inputColor.r * 0.5, inputColor.g, inputColor.b * 0.8, inputColor.a); // Tint
 
-    if (isBlack && isTransparent) { // If input is black AND transparent (typical for unbound/default texture)
-        FragColor = vec4(1.0, 0.0, 1.0, 1.0); // Bright Magenta for unbound/empty input
-    } else if (isBlack) { // If input is black but opaque (Plasma might be outputting black)
-        FragColor = vec4(1.0, 0.0, 0.0, 1.0); // Bright Red for black input
-    }
-    else {
-        // Simple effect: desaturate or tint the input
-        // float grayscale = dot(inputColor.rgb, vec3(0.299, 0.587, 0.114));
-        // FragColor = vec4(vec3(grayscale), inputColor.a); // Grayscale
-        FragColor = vec4(inputColor.r * 0.5, inputColor.g, inputColor.b * 0.8, inputColor.a); // Tint
-    }
+    // Fallback diagnostic colors removed. iResolution can also be removed if not used by tint.
+    // For now, keeping iResolution declaration in case it's used by other effects or future passthrough versions.
 }


### PR DESCRIPTION
- Timeline now plays by default on startup (g_timeline_paused = false).
- Restored raymarch_v1.frag (Plasma) to its original rendering logic.
- Cleaned up passthrough.frag, removing diagnostic colors.
- Ensured main.cpp renders Passthrough (Final Output) by default.
- Introduced g_timelineControlActive (default false) to allow users to explicitly enable UI control over timeline pause/play/reset.
- Added "Enable Timeline Keyframe Control" checkbox in RenderTimelineWindow. Timeline UI controls (Play/Pause, Reset) are now visually and functionally conditional on this new flag.
- Includes previously added OpenGL error checking utilities.