### PR TITLE
Phase 5: Node System (Part 1 - UI Placeholders)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -779,6 +779,9 @@ void RenderTimelineWindow() {
 
 void RenderNodeEditorWindow() {
     ImGui::Begin("Node Editor");
+
+    // Use a child window to make the empty space context-clickable
+    ImGui::BeginChild("NodeEditorCanvas", ImVec2(0,0), false, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
     ImNodes::BeginNodeEditor();
     for (const auto& effect_ptr : g_scene) {
         if (!effect_ptr) continue;
@@ -818,7 +821,33 @@ void RenderNodeEditorWindow() {
             else if (!start_is_output && !end_is_input) { start_effect->SetInputEffect((start_attr % 10) - 1, end_effect); }
         }
     }
-    ImGui::End();
+
+    // Context menu for adding nodes
+    if (ImGui::BeginPopupContextWindow("NodeEditorContextMenu")) {
+        if (ImGui::BeginMenu("Add Effect")) {
+            if (ImGui::BeginMenu("Generators")) {
+                if (ImGui::MenuItem("Plasma (nyi)")) { /* Placeholder */ }
+                if (ImGui::MenuItem("Noise (nyi)")) { /* Placeholder */ }
+                ImGui::EndMenu();
+            }
+            if (ImGui::BeginMenu("Filters")) {
+                if (ImGui::MenuItem("Blur (nyi)")) { /* Placeholder */ }
+                if (ImGui::MenuItem("Vignette (nyi)")) { /* Placeholder */ }
+                ImGui::EndMenu();
+            }
+            if (ImGui::BeginMenu("Image Operations")) {
+                if (ImGui::MenuItem("Load Image (nyi)")) { /* Placeholder */ }
+                ImGui::EndMenu();
+            }
+            ImGui::Separator();
+            if (ImGui::MenuItem("Passthrough Shader (nyi)")) { /* Placeholder for basic ShaderEffect */ }
+            ImGui::EndMenu();
+        }
+        ImGui::EndPopup();
+    }
+    ImNodes::EndNodeEditor(); // End node editor before ending child window
+    ImGui::EndChild(); // End NodeEditorCanvas
+    ImGui::End(); // End Node Editor window
 }
 
 void RenderConsoleWindow() {


### PR DESCRIPTION
- Analyzed default shader and current startup: confirmed existing single 'Passthrough (Final Output)' effect is a minimal setup.
- No changes needed to startup logic as it already implements the minimal node configuration.
- Conceptually designed the Node Template System: decided on C++ factory functions for templates initially, and a right-click context menu in the Node Editor for the UI.
- Implemented a placeholder UI for adding nodes in `RenderNodeEditorWindow()`:
  - Wrapped node editor in a child window to enable context menu on empty space.
  - Added a right-click context menu ('NodeEditorContextMenu') with 'Add Effect' and categorized placeholder menu items (e.g., Generators > Plasma (nyi), Filters > Blur (nyi)).

Build is successful. This sets up the UI foundation for adding node templates later.