### PR TITLE
Phase 5: Node System (Node Template Implementation)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ add_executable(RaymarchVibe
   src/AudioSystem.cpp # Ensure this file defines MINIAUDIO_IMPLEMENTATION if using miniaudio header-only
   src/Utils.cpp
   src/ShadertoyIntegration.cpp
+  src/NodeTemplates.cpp
 )
 
 target_include_directories(RaymarchVibe PRIVATE

--- a/include/NodeTemplates.h
+++ b/include/NodeTemplates.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <memory> // For std::unique_ptr
+#include <string> // For std::string
+
+// Forward declare Effect class to avoid full include if only pointers/references are needed.
+// However, since we return std::unique_ptr<Effect>, a full definition of Effect is needed
+// by the caller of these factory functions. For simplicity in this module,
+// we might just include Effect.h if it's lightweight.
+// Assuming Effect.h is included where these functions are called (e.g., main.cpp)
+// or we include it here. For now, forward declare.
+class Effect;
+
+namespace RaymarchVibe {
+namespace NodeTemplates {
+
+// Default width and height for new effects created from templates
+const int DEFAULT_TEMPLATE_EFFECT_WIDTH = 800;
+const int DEFAULT_TEMPLATE_EFFECT_HEIGHT = 600;
+
+std::unique_ptr<Effect> CreateSimpleColorEffect(
+    int initial_width = DEFAULT_TEMPLATE_EFFECT_WIDTH,
+    int initial_height = DEFAULT_TEMPLATE_EFFECT_HEIGHT);
+
+std::unique_ptr<Effect> CreateInvertColorEffect(
+    int initial_width = DEFAULT_TEMPLATE_EFFECT_WIDTH,
+    int initial_height = DEFAULT_TEMPLATE_EFFECT_HEIGHT);
+
+std::unique_ptr<Effect> CreatePlasmaBasicEffect(
+    int initial_width = DEFAULT_TEMPLATE_EFFECT_WIDTH,
+    int initial_height = DEFAULT_TEMPLATE_EFFECT_HEIGHT);
+
+// Add declarations for other templates here
+
+} // namespace NodeTemplates
+} // namespace RaymarchVibe

--- a/shaders/templates/invert_color.frag
+++ b/shaders/templates/invert_color.frag
@@ -1,0 +1,11 @@
+#version 330 core
+out vec4 FragColor;
+
+in vec2 TexCoords;
+
+uniform sampler2D iChannel0; // Input texture
+
+void main() {
+    vec4 texColor = texture(iChannel0, TexCoords);
+    FragColor = vec4(1.0 - texColor.rgb, texColor.a);
+}

--- a/shaders/templates/plasma_basic.frag
+++ b/shaders/templates/plasma_basic.frag
@@ -1,0 +1,36 @@
+#version 330 core
+out vec4 FragColor;
+
+uniform vec2 iResolution;
+uniform float iTime;
+
+// Basic plasma effect
+// Credits to Inigo Quilez for the general plasma concepts
+// This is a highly simplified version
+
+float plot(vec2 st, float pct){
+  return  smoothstep( pct-0.02, pct, st.y) -
+          smoothstep( pct, pct+0.02, st.y);
+}
+
+void main() {
+    vec2 uv = gl_FragCoord.xy / iResolution.xy;
+
+    float timeScaled = iTime * 0.5;
+
+    float color = 0.0;
+    color += sin(uv.x * 5.0 + timeScaled * 2.0);
+    color += sin(uv.y * 8.0 + timeScaled * 1.5);
+    color += sin((uv.x + uv.y) * 10.0 + timeScaled * 3.0);
+    color = sin( (uv.x*sin(timeScaled*0.2)+uv.y*cos(timeScaled*0.3)) * 10.0 + color * 2.0); // More complex interaction
+    color = mod(color, 1.0); // Ensure it wraps around
+
+    // Simple color mapping
+    vec3 plasmaColor = vec3(
+        sin(color * 3.14159 + 0.0 + timeScaled*0.1) * 0.5 + 0.5,
+        sin(color * 3.14159 + 2.09439 + timeScaled*0.2) * 0.5 + 0.5, // 2PI/3
+        sin(color * 3.14159 + 4.18879 + timeScaled*0.3) * 0.5 + 0.5  // 4PI/3
+    );
+
+    FragColor = vec4(plasmaColor, 1.0);
+}

--- a/shaders/templates/simple_color.frag
+++ b/shaders/templates/simple_color.frag
@@ -1,0 +1,9 @@
+#version 330 core
+out vec4 FragColor;
+
+uniform vec3 u_color = vec3(1.0, 0.7, 0.2); // Default to an orange color
+// #control vec3 u_color "Color" { "default": [1.0, 0.7, 0.2], "min": [0.0,0.0,0.0], "max": [1.0,1.0,1.0], "colortype": "rgb" }
+
+void main() {
+    FragColor = vec4(u_color, 1.0);
+}

--- a/src/NodeTemplates.cpp
+++ b/src/NodeTemplates.cpp
@@ -1,0 +1,49 @@
+#include "NodeTemplates.h"
+#include "ShaderEffect.h" // Needs full definition of ShaderEffect
+#include "Effect.h"       // For std::unique_ptr<Effect>
+
+// Note: ShaderEffect constructor takes:
+// ShaderEffect(const std::string& initialShaderPath = "", int initialWidth = 800, int initialHeight = 600, bool isShadertoy = false);
+
+namespace RaymarchVibe {
+namespace NodeTemplates {
+
+std::unique_ptr<Effect> CreateSimpleColorEffect(int initial_width, int initial_height) {
+    auto effect = std::make_unique<ShaderEffect>(
+        "shaders/templates/simple_color.frag",
+        initial_width,
+        initial_height
+    );
+    effect->name = "Simple Color";
+    // effect->Load(); // Important: Call Load() after creation to compile shader, etc.
+                     // This should ideally be done after adding to scene and before first render of it.
+                     // For now, let's assume the caller (e.g. main.cpp) will call Load().
+    return effect;
+}
+
+std::unique_ptr<Effect> CreateInvertColorEffect(int initial_width, int initial_height) {
+    auto effect = std::make_unique<ShaderEffect>(
+        "shaders/templates/invert_color.frag",
+        initial_width,
+        initial_height
+    );
+    effect->name = "Invert Color";
+    // effect->Load();
+    return effect;
+}
+
+std::unique_ptr<Effect> CreatePlasmaBasicEffect(int initial_width, int initial_height) {
+    auto effect = std::make_unique<ShaderEffect>(
+        "shaders/templates/plasma_basic.frag",
+        initial_width,
+        initial_height
+    );
+    effect->name = "Basic Plasma";
+    // effect->Load();
+    return effect;
+}
+
+// Implement other factory functions here
+
+} // namespace NodeTemplates
+} // namespace RaymarchVibe

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@
 #include "imnodes.h"
 #include "ImGuiFileDialog.h"
 #include "AudioSystem.h" // Added the actual AudioSystem header
+#include "NodeTemplates.h" // For node template factory functions
 
 // Placeholder Audio System has been removed.
 
@@ -826,21 +827,44 @@ void RenderNodeEditorWindow() {
     if (ImGui::BeginPopupContextWindow("NodeEditorContextMenu")) {
         if (ImGui::BeginMenu("Add Effect")) {
             if (ImGui::BeginMenu("Generators")) {
-                if (ImGui::MenuItem("Plasma (nyi)")) { /* Placeholder */ }
-                if (ImGui::MenuItem("Noise (nyi)")) { /* Placeholder */ }
+                if (ImGui::MenuItem("Basic Plasma")) {
+                    auto newEffect = RaymarchVibe::NodeTemplates::CreatePlasmaBasicEffect();
+                    if (newEffect) {
+                        newEffect->Load(); // Important: Load after creation
+                        ImNodes::SetNodeScreenSpacePos(newEffect->id, ImGui::GetMousePos()); // Position near mouse
+                        g_scene.push_back(std::move(newEffect));
+                    }
+                }
+                if (ImGui::MenuItem("Simple Color")) {
+                    auto newEffect = RaymarchVibe::NodeTemplates::CreateSimpleColorEffect();
+                    if (newEffect) {
+                        newEffect->Load();
+                        ImNodes::SetNodeScreenSpacePos(newEffect->id, ImGui::GetMousePos());
+                        g_scene.push_back(std::move(newEffect));
+                    }
+                }
+                // if (ImGui::MenuItem("Noise (nyi)")) { /* Placeholder */ }
                 ImGui::EndMenu();
             }
             if (ImGui::BeginMenu("Filters")) {
-                if (ImGui::MenuItem("Blur (nyi)")) { /* Placeholder */ }
-                if (ImGui::MenuItem("Vignette (nyi)")) { /* Placeholder */ }
+                if (ImGui::MenuItem("Invert Color")) {
+                     auto newEffect = RaymarchVibe::NodeTemplates::CreateInvertColorEffect();
+                    if (newEffect) {
+                        newEffect->Load();
+                        ImNodes::SetNodeScreenSpacePos(newEffect->id, ImGui::GetMousePos());
+                        g_scene.push_back(std::move(newEffect));
+                    }
+                }
+                // if (ImGui::MenuItem("Blur (nyi)")) { /* Placeholder */ }
+                // if (ImGui::MenuItem("Vignette (nyi)")) { /* Placeholder */ }
                 ImGui::EndMenu();
             }
-            if (ImGui::BeginMenu("Image Operations")) {
-                if (ImGui::MenuItem("Load Image (nyi)")) { /* Placeholder */ }
-                ImGui::EndMenu();
-            }
-            ImGui::Separator();
-            if (ImGui::MenuItem("Passthrough Shader (nyi)")) { /* Placeholder for basic ShaderEffect */ }
+            // if (ImGui::BeginMenu("Image Operations")) {
+            //     if (ImGui::MenuItem("Load Image (nyi)")) { /* Placeholder */ }
+            //     ImGui::EndMenu();
+            // }
+            // ImGui::Separator();
+            // if (ImGui::MenuItem("Passthrough Shader (nyi)")) { /* Placeholder for basic ShaderEffect */ }
             ImGui::EndMenu();
         }
         ImGui::EndPopup();


### PR DESCRIPTION
- Created shader files for basic node templates:
  - shaders/templates/simple_color.frag
  - shaders/templates/invert_color.frag
  - shaders/templates/plasma_basic.frag
- Implemented Node Template factory functions in NodeTemplates.h/.cpp for these effects.
- Added NodeTemplates.cpp to CMakeLists.txt.
- Connected the Node Editor's context menu UI to these factory functions:
  - New effects are created, Load() is called on them.
  - Attempt to position new nodes near the mouse cursor using ImNodes::SetNodeScreenSpacePos().

This allows users to add basic 'Simple Color', 'Invert Color', and 'Basic Plasma' shader effects to the node graph via the UI.