### PR TITLE
Integrate basic ImGui theming system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ add_executable(RaymarchVibe
   src/Utils.cpp
   src/ShadertoyIntegration.cpp
   src/NodeTemplates.cpp
+  themes.cpp # Added themes.cpp
 )
 
 target_include_directories(RaymarchVibe PRIVATE

--- a/include/Bess/Config/Themes.h
+++ b/include/Bess/Config/Themes.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <functional>
+#include <unordered_map>
+#include "imgui.h" // Assuming imgui.h is accessible in the include path
+
+namespace Bess {
+namespace Config {
+
+class Themes {
+public:
+    Themes();
+    void applyTheme(const std::string &theme);
+    void addTheme(const std::string &name, const std::function<void()> &callback);
+    const std::unordered_map<std::string, std::function<void()>> &getThemes() const;
+
+    // Utility function, can be public if needed elsewhere, or kept private / moved to .cpp
+    static ImVec4 BlendColors(const ImVec4 &base, const ImVec4 &accent, float blendFactor);
+
+private:
+    std::unordered_map<std::string, std::function<void()>> m_themes;
+
+    void setDarkThemeColors();
+    void setModernDarkColors();
+    void setCatpuccinMochaColors();
+    void setBessDarkColors();
+    void setFluentUIColors();
+    // Add any other private theme-setting methods if new themes are added directly in themes.cpp
+};
+
+} // namespace Config
+} // namespace Bess

--- a/src/UIManager.cpp
+++ b/src/UIManager.cpp
@@ -58,6 +58,7 @@ void UIManager::Initialize() {
     auto lang = TextEditor::LanguageDefinition::GLSL();
     m_editor_ref.SetLanguageDefinition(lang);
     m_editor_ref.SetShowWhitespaces(false);
+    m_themes.applyTheme("Bess Dark"); // Apply a default theme
 }
 
 void UIManager::SetupInitialEditorAndShader() {
@@ -167,6 +168,20 @@ void UIManager::RenderMenuBar(GLFWwindow* window) {
             if (ImGui::MenuItem("Snap Windows to Default Layout")) { RequestWindowSnap(); }
             if (ImGui::MenuItem("Toggle Fullscreen", "F12")) { requestFullscreenToggle(); }
             if (ImGui::MenuItem("Toggle GUI", "Spacebar")) { m_showGui_ref = !m_showGui_ref; }
+            ImGui::EndMenu();
+        }
+
+        if (ImGui::BeginMenu("Settings")) { // New Settings Menu
+            if (ImGui::BeginMenu("Themes")) {
+                const auto& availableThemes = m_themes.getThemes();
+                // TODO: Get current theme to show a checkmark next to it. For now, just list them.
+                for (const auto& pair : availableThemes) {
+                    if (ImGui::MenuItem(pair.first.c_str())) {
+                        m_themes.applyTheme(pair.first);
+                    }
+                }
+                ImGui::EndMenu();
+            }
             ImGui::EndMenu();
         }
 

--- a/src/UIManager.h
+++ b/src/UIManager.h
@@ -6,6 +6,7 @@
 #include "ShaderParser.h"
 #include "AudioSystem.h"
 #include "TextEditor.h"
+#include "Bess/Config/Themes.h" // Added Themes header
 #include <string>
 #include <vector>
 
@@ -129,6 +130,7 @@ private:
 
     // Internal state for UI
     bool m_snapWindows = false;
+    Bess::Config::Themes m_themes; // Added Themes object
 
     // --- Find Functionality State ---
     char m_findText[256];

--- a/themes.cpp
+++ b/themes.cpp
@@ -1,6 +1,6 @@
-#include "settings/themes.h"
+#include "Bess/Config/Themes.h" // Changed include path
 #include "imgui.h"
-#include "settings/viewport_theme.h"
+// #include "settings/viewport_theme.h" // Removed missing header
 
 namespace Bess::Config {
     Themes::Themes() {
@@ -16,7 +16,7 @@ namespace Bess::Config {
             return;
 
         m_themes[theme]();
-        ViewportTheme::updateColorsFromImGuiStyle();
+        // ViewportTheme::updateColorsFromImGuiStyle(); // Removed call to missing ViewportTheme
     }
 
     void Themes::addTheme(const std::string &name, const std::function<void()> &callback) {
@@ -150,8 +150,8 @@ namespace Bess::Config {
         colors[ImGuiCol_TabActive] = ImVec4(0.76f, 0.46f, 0.58f, 1.00f);            // Pink
         colors[ImGuiCol_TabUnfocused] = ImVec4(0.18f, 0.16f, 0.22f, 1.00f);         // Mantle
         colors[ImGuiCol_TabUnfocusedActive] = ImVec4(0.21f, 0.18f, 0.25f, 1.00f);   // Crust
-        colors[ImGuiCol_DockingPreview] = ImVec4(0.95f, 0.66f, 0.47f, 0.70f);       // Peach
-        colors[ImGuiCol_DockingEmptyBg] = ImVec4(0.12f, 0.12f, 0.12f, 1.00f);       // Base
+        // colors[ImGuiCol_DockingPreview] = ImVec4(0.95f, 0.66f, 0.47f, 0.70f);       // Peach // Likely missing due to ImGui docking config
+        // colors[ImGuiCol_DockingEmptyBg] = ImVec4(0.12f, 0.12f, 0.12f, 1.00f);       // Base    // Likely missing due to ImGui docking config
         colors[ImGuiCol_PlotLines] = ImVec4(0.82f, 0.61f, 0.85f, 1.00f);            // Lavender
         colors[ImGuiCol_PlotLinesHovered] = ImVec4(0.89f, 0.54f, 0.79f, 1.00f);     // Pink
         colors[ImGuiCol_PlotHistogram] = ImVec4(0.82f, 0.61f, 0.85f, 1.00f);        // Lavender
@@ -232,8 +232,8 @@ namespace Bess::Config {
         colors[ImGuiCol_TabActive] = ImVec4(0.28f, 0.38f, 0.59f, 1.00f);
         colors[ImGuiCol_TabUnfocused] = ImVec4(0.15f, 0.18f, 0.22f, 1.00f);
         colors[ImGuiCol_TabUnfocusedActive] = ImVec4(0.15f, 0.18f, 0.22f, 1.00f);
-        colors[ImGuiCol_DockingPreview] = ImVec4(0.28f, 0.56f, 1.00f, 1.00f);
-        colors[ImGuiCol_DockingEmptyBg] = ImVec4(0.13f, 0.14f, 0.15f, 1.00f);
+        // colors[ImGuiCol_DockingPreview] = ImVec4(0.28f, 0.56f, 1.00f, 1.00f); // Likely missing due to ImGui docking config
+        // colors[ImGuiCol_DockingEmptyBg] = ImVec4(0.13f, 0.14f, 0.15f, 1.00f); // Likely missing due to ImGui docking config
         colors[ImGuiCol_PlotLines] = ImVec4(0.61f, 0.61f, 0.61f, 1.00f);
         colors[ImGuiCol_PlotLinesHovered] = ImVec4(1.00f, 0.43f, 0.35f, 1.00f);
         colors[ImGuiCol_PlotHistogram] = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
@@ -351,8 +351,8 @@ namespace Bess::Config {
         colors[ImGuiCol_TabActive] = ImVec4(0.40f, 0.40f, 0.40f, 1.00f);
         colors[ImGuiCol_TabUnfocused] = ImVec4(0.18f, 0.18f, 0.18f, 1.00f);
         colors[ImGuiCol_TabUnfocusedActive] = ImVec4(0.40f, 0.40f, 0.40f, 1.00f);
-        colors[ImGuiCol_DockingPreview] = ImVec4(0.45f, 0.45f, 0.45f, 1.00f); // Docking preview in gray
-        colors[ImGuiCol_DockingEmptyBg] = ImVec4(0.18f, 0.18f, 0.18f, 1.00f); // Empty dock background
+        // colors[ImGuiCol_DockingPreview] = ImVec4(0.45f, 0.45f, 0.45f, 1.00f); // Docking preview in gray // Likely missing due to ImGui docking config
+        // colors[ImGuiCol_DockingEmptyBg] = ImVec4(0.18f, 0.18f, 0.18f, 1.00f); // Empty dock background // Likely missing due to ImGui docking config
         // Additional styles
         style.FramePadding = ImVec2(8.0f, 4.0f);
         style.ItemSpacing = ImVec2(8.0f, 4.0f);


### PR DESCRIPTION
- Created Themes.h based on themes.cpp
- Modified themes.cpp to use the new header and removed dependencies on missing viewport_theme.h
- Integrated theme selection into UIManager:
  - Added a Themes object to UIManager.
  - Applied "Bess Dark" as the default theme on startup.
  - Added a "Settings" -> "Themes" menu for theme selection.
- Updated CMakeLists.txt to include themes.cpp in the build.
- Commented out ImGuiCol_DockingPreview and ImGuiCol_DockingEmptyBg in themes.cpp to resolve build errors due to ImGui docking configuration in the project.
- Added necessary build dependencies for GLFW and OpenGL during the build and test phase.