### PR TITLE
Fix ImNodes assertion and multiple timeline stability issues

### DIFF
--- a/include/ImGuiSimpleTimeline.h
+++ b/include/ImGuiSimpleTimeline.h
@@ -95,13 +95,22 @@ inline bool SimpleTimeline(const char* label, std::vector<TimelineItem>& items, 
     // Major ticks should have labels, so they need more space
     float major_tick_interval_seconds = minor_tick_interval_seconds;
     while (pixels_per_second * major_tick_interval_seconds < min_pixels_per_tick_label) {
-        if (major_tick_interval_seconds < 1.0f) major_tick_interval_seconds *= 2.0f; // 0.1 -> 0.2 -> 0.4 (approx 0.5) -> 0.8 (approx 1.0)
-        else if (major_tick_interval_seconds < 5.0f) major_tick_interval_seconds = ceil(major_tick_interval_seconds / 1.0f) * 1.0f + 1.0f; // 1->2, 2->3 etc
-        else if (major_tick_interval_seconds < 10.0f) major_tick_interval_seconds = 5.0f;
-        else if (major_tick_interval_seconds < 30.0f) major_tick_interval_seconds = 10.0f;
-        else if (major_tick_interval_seconds < 60.0f) major_tick_interval_seconds = 30.0f;
-        else if (major_tick_interval_seconds < 5*60.0f) major_tick_interval_seconds = 60.0f;
-        else major_tick_interval_seconds *= 2.0f; // For larger intervals
+        if (major_tick_interval_seconds < 1.0f) {
+            major_tick_interval_seconds *= 2.0f;
+            if (major_tick_interval_seconds == 0.0f) major_tick_interval_seconds = 0.01f; // Prevent getting stuck at 0 if initial was 0
+        } else if (major_tick_interval_seconds < 5.0f) {
+            major_tick_interval_seconds = 5.0f;
+        } else if (major_tick_interval_seconds < 10.0f) {
+            major_tick_interval_seconds = 10.0f;
+        } else if (major_tick_interval_seconds < 30.0f) {
+            major_tick_interval_seconds = 30.0f;
+        } else if (major_tick_interval_seconds < 60.0f) { // Less than 1 minute
+            major_tick_interval_seconds = 60.0f; // Jump to 1 minute
+        } else if (major_tick_interval_seconds < 5 * 60.0f) { // Less than 5 minutes
+            major_tick_interval_seconds = 5 * 60.0f; // Jump to 5 minutes
+        } else { // For larger intervals, double it
+            major_tick_interval_seconds *= 2.0f;
+        }
 
         // Safety break for extremely zoomed out cases
         if (major_tick_interval_seconds > overall_sequence_duration / 2.0f && overall_sequence_duration > 0) {


### PR DESCRIPTION
This commit addresses several bugs:

1. ImNodes Assertion: Moved ImNodes::IsLinkCreated call in RenderNodeEditorWindow to be outside the Begin/EndNodeEditor scope, resolving an assertion failure (GImNodes->CurrentScope == ImNodesScope_None).

2. Timeline Running by Default: Modified the main loop's active effect determination. If the timeline master control (g_timelineState.isEnabled) is false, all effects are now considered active, preventing the screen from going blank when glfwGetTime() exceeded default effect durations.

3. Timeline Window Stability (track_indices_storage): Changed the `tracks` vector in RenderTimelineWindow to `static std::vector<int> track_indices_storage` to ensure pointers to track indices passed to ImGui::SimpleTimeline remain valid, preventing potential crashes.

4. Timeline Zoom Hang: Corrected logic in the `while` loop that calculates `major_tick_interval_seconds` within `ImGuiSimpleTimeline.h`. Ensured that `major_tick_interval_seconds` always strictly increases or jumps to the next sensible common interval, preventing stagnation and potential infinite loops when zooming.

5. Code Cleanup: Removed temporary std::cerr debugging logs added during the diagnostic process and restored previously commented-out HelpMarker calls in RenderTimelineWindow.